### PR TITLE
refactor: 룩북 페이지 - 접근성 개선 · 스와이퍼 분리 · 성능 최적화 적용(React.lazy)

### DIFF
--- a/src/components/LookBook/LookBookSwiper.jsx
+++ b/src/components/LookBook/LookBookSwiper.jsx
@@ -24,7 +24,7 @@ export default function LookBookSwiper({ lookBookItems, handleImageClick, swiper
       ref={swiperRef}
     >
       {lookBookItems.length > 0 ? (
-        lookBookItems.map((item, i) => (
+        lookBookItems.map((item) => (
           <SwiperSlide key={item.id}>
             <NavLink to={`/lookbook/${item.id}`}>
               <img
@@ -32,9 +32,6 @@ export default function LookBookSwiper({ lookBookItems, handleImageClick, swiper
                 alt={item.lookBookTitle}
                 className={styles.outfitImage}
                 onClick={() => handleImageClick(item)}
-                loading={i === 0 ? 'eager' : 'lazy'}
-                fetchPriority={i === 0 ? 'high' : 'auto'}
-                decoding="async"
               />
             </NavLink>
           </SwiperSlide>

--- a/src/components/LookBook/LookBookSwiper.jsx
+++ b/src/components/LookBook/LookBookSwiper.jsx
@@ -24,7 +24,7 @@ export default function LookBookSwiper({ lookBookItems, handleImageClick, swiper
       ref={swiperRef}
     >
       {lookBookItems.length > 0 ? (
-        lookBookItems.map((item) => (
+        lookBookItems.map((item, i) => (
           <SwiperSlide key={item.id}>
             <NavLink to={`/lookbook/${item.id}`}>
               <img
@@ -32,6 +32,9 @@ export default function LookBookSwiper({ lookBookItems, handleImageClick, swiper
                 alt={item.lookBookTitle}
                 className={styles.outfitImage}
                 onClick={() => handleImageClick(item)}
+                loading={i === 0 ? 'eager' : 'lazy'}
+                fetchPriority={i === 0 ? 'high' : 'auto'}
+                decoding="async"
               />
             </NavLink>
           </SwiperSlide>

--- a/src/components/LookBook/LookBookSwiper.jsx
+++ b/src/components/LookBook/LookBookSwiper.jsx
@@ -1,0 +1,44 @@
+import { NavLink } from 'react-router-dom';
+import styles from './../../styles/pages/LookBookpage.module.scss';
+import getPbImageURL from './../../api/getPbImageURL';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { A11y, Keyboard, Pagination, Scrollbar } from 'swiper/modules';
+import 'swiper/scss';
+import 'swiper/scss/pagination';
+
+export default function LookBookSwiper({ lookBookItems, handleImageClick, swiperRef }) {
+  return (
+    <Swiper
+      className={styles.swiper}
+      modules={[Pagination, Scrollbar, A11y, Keyboard]}
+      spaceBetween={20}
+      slidesPerView={1.2}
+      loop={lookBookItems.length > 1}
+      keyboard={{ enabled: true }}
+      pagination={{ clickable: true }}
+      a11y={{
+        prevSlideMessage: '이전 슬라이드',
+        nextSlideMessage: '다음 슬라이드',
+        paginationBulletMessage: '페이지 {{index}}',
+      }}
+      ref={swiperRef}
+    >
+      {lookBookItems.length > 0 ? (
+        lookBookItems.map((item) => (
+          <SwiperSlide key={item.id}>
+            <NavLink to={`/lookbook/${item.id}`}>
+              <img
+                src={getPbImageURL(item, 'outfitImage')}
+                alt={item.lookBookTitle}
+                className={styles.outfitImage}
+                onClick={() => handleImageClick(item)}
+              />
+            </NavLink>
+          </SwiperSlide>
+        ))
+      ) : (
+        <SwiperSlide>계절에 맞는 착용샷이 없습니다.</SwiperSlide>
+      )}
+    </Swiper>
+  );
+}

--- a/src/components/LookBook/RefreshButton.jsx
+++ b/src/components/LookBook/RefreshButton.jsx
@@ -6,6 +6,9 @@ export function RefreshButton({ onRefresh }) {
   return (
     <div className={styles.refreshBtn}>
       <Button
+        type="button"
+        aria-label="추천 코디 새로고침"
+        title="추천 코디 새로고침"
         icon={<IoRefreshSharp />}
         active={true}
         onClick={onRefresh}

--- a/src/components/LookBook/RefreshButton.jsx
+++ b/src/components/LookBook/RefreshButton.jsx
@@ -1,4 +1,4 @@
-import styles from './../../styles/pages/Lookbookpage.module.scss';
+import styles from './../../styles/pages/LookBookpage.module.scss';
 import Button from './../../components/Button/Button';
 import { IoRefreshSharp } from 'react-icons/io5';
 

--- a/src/components/LookBook/RefreshButton.jsx
+++ b/src/components/LookBook/RefreshButton.jsx
@@ -1,0 +1,22 @@
+import styles from './../../styles/pages/Lookbookpage.module.scss';
+import Button from './../../components/Button/Button';
+import { IoRefreshSharp } from 'react-icons/io5';
+
+export function RefreshButton({ onRefresh }) {
+  return (
+    <div className={styles.refreshBtn}>
+      <Button
+        icon={<IoRefreshSharp />}
+        active={true}
+        onClick={onRefresh}
+        style={{
+          backgroundColor: 'transparent',
+          border: 'none',
+          width: '31px',
+          height: '31px',
+          marginLeft: '-4px',
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/LookBook/RefreshButton.jsx
+++ b/src/components/LookBook/RefreshButton.jsx
@@ -9,7 +9,7 @@ export function RefreshButton({ onRefresh }) {
         type="button"
         aria-label="추천 코디 새로고침"
         title="추천 코디 새로고침"
-        icon={<IoRefreshSharp />}
+        icon={<IoRefreshSharp aria-hidden="true" />}
         active={true}
         onClick={onRefresh}
         style={{

--- a/src/components/LookBook/WeatherIcon.jsx
+++ b/src/components/LookBook/WeatherIcon.jsx
@@ -1,4 +1,4 @@
-import styles from './../../styles/pages/Lookbookpage.module.scss';
+import styles from './../../styles/pages/LookBookpage.module.scss';
 
 export function WeatherIcon({ weatherIcon }) {
   return (

--- a/src/components/LookBook/WeatherIcon.jsx
+++ b/src/components/LookBook/WeatherIcon.jsx
@@ -1,0 +1,9 @@
+import styles from './../../styles/pages/Lookbookpage.module.scss';
+
+export function WeatherIcon({ weatherIcon }) {
+  return (
+    <div className={styles.weatherIcon}>
+      <img src={weatherIcon.src} alt={weatherIcon.alt} />
+    </div>
+  );
+}

--- a/src/hooks/useRefresh.js
+++ b/src/hooks/useRefresh.js
@@ -1,0 +1,47 @@
+import { useCallback } from 'react';
+import pb from './../api/pocketbase';
+
+export function useRefresh({ lookBookItems, setLookBookItems, season, swiperRef }) {
+  const handleRefresh = useCallback(async () => {
+    try {
+      const items = await pb.collection('lookBook').getFullList();
+
+      // 현재 착용샷의 id 배열로 만듦(중복 방지)
+      const currentSeasonItemIds = lookBookItems.map((item) => item.id);
+
+      // 계절용 - 새로운 아이템(중복 X)
+      const newSeasonItems = items
+        .filter(
+          (item) => item.lookBookSeason.includes(season) && !currentSeasonItemIds.includes(item.id)
+        )
+        .sort(() => 0.5 - Math.random())
+        .slice(0, 2);
+
+      // 범용 - 새로운 아이템(중복 X)
+      const newAllSeasonItems = items
+        .filter(
+          (item) => item.lookBookSeason.includes('범용') && !currentSeasonItemIds.includes(item.id)
+        )
+        .sort(() => 0.5 - Math.random())
+        .slice(0, 3);
+
+      // 새로운 착용샷(계절용 + 범용) 업데이트
+      const newLookBookItems = [...newSeasonItems, ...newAllSeasonItems];
+
+      setLookBookItems(newLookBookItems);
+
+      // 새로운 착용샷 세션에 저장
+      // - 상세 페이지에서 돌아올 시 착용샷 유지를 위함
+      sessionStorage.setItem('lookBookItems', JSON.stringify(newLookBookItems));
+
+      // 첫 번째 슬라이드로 돌아오기
+      if (swiperRef.current && swiperRef.current.swiper) {
+        swiperRef.current.swiper.slideTo(0);
+      }
+    } catch (error) {
+      console.error('새로고침 중 에러 발생:', error);
+    }
+  }, [lookBookItems, setLookBookItems, season, swiperRef]);
+
+  return { handleRefresh }
+}

--- a/src/pages/LookbookPage.jsx
+++ b/src/pages/LookbookPage.jsx
@@ -141,39 +141,53 @@ function LookBookPage() {
       </Helmet>
 
       <div className={styles.wrapComponent}>
-        <div className={styles.topWrapper}>
-          <h2 className={styles.title}>Look Book : OOTD</h2>
+        <header className={styles.topWrapper}>
+          <h1 className={styles.title}>Look Book : OOTD</h1>
 
           <RefreshButton onRefresh={handleRefresh} />
-        </div>
+        </header>
 
-        <WeatherIcon weatherIcon={weatherIcon} />
+        <main>
+          <WeatherIcon weatherIcon={weatherIcon} />
 
-        <div className={styles.subTitle}>
-          <p className={styles.description}>
-            오늘 날씨엔 <br />
-            이런 스타일 어때요?
-          </p>
+          <div className={styles.subTitle}>
+            <p className={styles.description}>
+              오늘 날씨엔 <br />
+              이런 스타일 어때요?
+            </p>
 
-          <div className={styles.swiperBtn}>
-            <button className={styles.goPrev} type="button" onClick={goPrev}>
-              <GoChevronLeft />
-            </button>
-            <button className={styles.goNext} type="button" onClick={goNext}>
-              <GoChevronRight />
-            </button>
+            <div className={styles.swiperBtn}>
+              <button
+                className={styles.goPrev}
+                type="button"
+                onClick={goPrev}
+                aria-label="이전 룩북 보기"
+                title="이전 룩북 보기"
+              >
+                <GoChevronLeft aria-hidden="true" />
+              </button>
+              <button
+                className={styles.goNext}
+                type="button"
+                onClick={goNext}
+                aria-label="다음 룩북 보기"
+                title="다음 룩북 보기"
+              >
+                <GoChevronRight aria-hidden="true" />
+              </button>
+            </div>
           </div>
-        </div>
 
-        <div className={styles.outfitSwiper}>
-          <Suspense fallback={<div style={{ padding: 16 }}>룩북 페이지 로딩 중…</div>}>
-            <LookBookSwiper
-              swiperRef={swiperRef}
-              lookBookItems={lookBookItems}
-              handleImageClick={handleImageClick}
-            />
-          </Suspense>
-        </div>
+          <div className={styles.outfitSwiper}>
+            <Suspense fallback={<div style={{ padding: 16 }}>룩북 페이지 로딩 중…</div>}>
+              <LookBookSwiper
+                swiperRef={swiperRef}
+                lookBookItems={lookBookItems}
+                handleImageClick={handleImageClick}
+              />
+            </Suspense>
+          </div>
+        </main>
       </div>
     </>
   );

--- a/src/pages/LookbookPage.jsx
+++ b/src/pages/LookbookPage.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { GoChevronLeft, GoChevronRight } from 'react-icons/go';
-import { IoRefreshSharp } from 'react-icons/io5';
+
 import { useNavigate, Outlet, useLocation, NavLink } from 'react-router-dom';
 import { A11y, Keyboard, Pagination, Scrollbar } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
@@ -9,11 +9,12 @@ import 'swiper/scss';
 import 'swiper/scss/pagination';
 import getPbImageURL from './../api/getPbImageURL';
 import pb from './../api/pocketbase';
-import Button from './../components/Button/Button';
+
 import styles from './../styles/pages/Lookbookpage.module.scss';
 import { getWeatherIcon } from './../utils/weatherIcons';
 import { getSeason } from './../data/constant';
 import { WeatherIcon } from './../components/LookBook/WeatherIcon';
+import { RefreshButton } from './../components/LookBook/RefreshButton';
 
 function LookbookPage() {
   const navigate = useNavigate();
@@ -28,7 +29,7 @@ function LookbookPage() {
   const [lookBookItems, setLookBookItems] = useState([]);
 
   // 현재 착용샷
-  const [currentSeasonItems, setCurrentSeasonItems] = useState([]);
+  const [, setCurrentSeasonItems] = useState([]);
 
   // 현재 경로 저장
   // - 룩북p / 룩북 상세p 구분을 위함
@@ -186,20 +187,7 @@ function LookbookPage() {
         <div className={styles.topWrapper}>
           <h2 className={styles.title}>Look Book : OOTD</h2>
 
-          <div className={styles.refreshBtn}>
-            <Button
-              icon={<IoRefreshSharp />}
-              active={true}
-              onClick={handleRefresh}
-              style={{
-                backgroundColor: 'transparent',
-                border: 'none',
-                width: '31px',
-                height: '31px',
-                marginLeft: '-4px',
-              }}
-            />
-          </div>
+          <RefreshButton onRefresh={handleRefresh} />
         </div>
 
         <WeatherIcon weatherIcon={weatherIcon} />

--- a/src/pages/LookbookPage.jsx
+++ b/src/pages/LookbookPage.jsx
@@ -13,6 +13,7 @@ import Button from './../components/Button/Button';
 import styles from './../styles/pages/Lookbookpage.module.scss';
 import { getWeatherIcon } from './../utils/weatherIcons';
 import { getSeason } from './../data/constant';
+import { WeatherIcon } from './../components/LookBook/WeatherIcon';
 
 function LookbookPage() {
   const navigate = useNavigate();
@@ -201,9 +202,7 @@ function LookbookPage() {
           </div>
         </div>
 
-        <div className={styles.weatherIcon}>
-          <img src={weatherIcon.src} alt={weatherIcon.alt} />
-        </div>
+        <WeatherIcon weatherIcon={weatherIcon} />
 
         <div className={styles.subTitle}>
           <p className={styles.description}>

--- a/src/pages/LookbookPage.jsx
+++ b/src/pages/LookbookPage.jsx
@@ -15,6 +15,7 @@ import { getWeatherIcon } from './../utils/weatherIcons';
 import { getSeason } from './../data/constant';
 import { WeatherIcon } from './../components/LookBook/WeatherIcon';
 import { RefreshButton } from './../components/LookBook/RefreshButton';
+import { useRefresh } from './../hooks/useRefresh';
 
 function LookbookPage() {
   const navigate = useNavigate();
@@ -120,47 +121,8 @@ function LookbookPage() {
     navigate(`/lookbook/${item.id}`);
   };
 
-  // 새로고침 기능 -----------------------------
-  const handleRefresh = async () => {
-    try {
-      const items = await pb.collection('lookBook').getFullList();
-
-      // 현재 착용샷의 id 배열로 만듦(중복 방지)
-      const currentSeasonItemIds = lookBookItems.map((item) => item.id);
-
-      // 계절용 - 새로운 아이템(중복 X)
-      const newSeasonItems = items
-        .filter(
-          (item) => item.lookBookSeason.includes(season) && !currentSeasonItemIds.includes(item.id)
-        )
-        .sort(() => 0.5 - Math.random())
-        .slice(0, 2);
-
-      // 범용 - 새로운 아이템(중복 X)
-      const newAllSeasonItems = items
-        .filter(
-          (item) => item.lookBookSeason.includes('범용') && !currentSeasonItemIds.includes(item.id)
-        )
-        .sort(() => 0.5 - Math.random())
-        .slice(0, 3);
-
-      // 새로운 착용샷(계절용 + 범용) 업데이트
-      const newLookBookItems = [...newSeasonItems, ...newAllSeasonItems];
-
-      setLookBookItems(newLookBookItems);
-
-      // 새로운 착용샷 세션에 저장
-      // - 상세 페이지에서 돌아올 시 착용샷 유지를 위함
-      sessionStorage.setItem('lookBookItems', JSON.stringify(newLookBookItems));
-
-      // 첫 번째 슬라이드로 돌아오기
-      if (swiperRef.current && swiperRef.current.swiper) {
-        swiperRef.current.swiper.slideTo(0);
-      }
-    } catch (error) {
-      console.error('새로고침 중 에러 발생:', error);
-    }
-  };
+  // 새로고침
+  const { handleRefresh } = useRefresh(lookBookItems, setLookBookItems, season, swiperRef);
 
   return isDetailPage ? (
     <Outlet />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -11,7 +11,7 @@ export { default as IntroPage } from './IntroPage';
 export { default as LikedPage } from './LikedPage';
 export { default as LoginPage } from './LoginPage';
 export { default as LookBookDetailPage } from './LookBookDetailPage';
-export { default as LookbookPage } from './LookbookPage';
+export { default as LookbookPage } from './LookBookPage';
 export { default as MainPage } from './MainPage';
 export { default as MyPage } from './MyPage';
 export { default as RegisterPage } from './RegisterPage';

--- a/src/routes/LookBookPageWrapper.jsx
+++ b/src/routes/LookBookPageWrapper.jsx
@@ -1,7 +1,7 @@
 import { Suspense, lazy } from 'react';
 import Fallback from '@/pages/Fallback';
 
-const LookbookPage = lazy(() => import('@/pages/LookbookPage'));
+const LookbookPage = lazy(() => import('@/pages/LookBookPage'));
 
 const LookbookPageWrapper = () => (
   <Suspense fallback={<Fallback />}>


### PR DESCRIPTION
# refactor: 룩북 페이지 - 접근성 개선 · 스와이퍼 분리 · 성능 최적화 적용(React.lazy)

## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] develop 브랜치에서 최신 데이터를 가져오기 위한 PR

<br/>

## PR 체크리스트
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 문서에 해당 변경 사항을 업데이트 했습니다.
- [x] 해당 변경은 에러를 발생시키지 않았습니다.

<br/>

### PR 상세(활동 및 수정사항)

#### 1) 아이콘 버튼 접근성 개선
* **Before**: 아이콘 전용 버튼(새로고침, 이전/다음)이 스크린리더에서 단순히 "button"으로만 읽힘 → 의미 파악 불가
* **After**:  
  * `aria-label` 속성 추가로 스크린리더에서 명확한 이름 제공  
  * `title` 속성 병행으로 마우스 사용자에게 툴팁 제공  
  * 아이콘에는 `aria-hidden="true"` 적용 → 중복 읽기 방지  

#### 2) 공통 Button 컴포넌트 보강
* **Before**: `aria-label`을 넘겨도 실제 DOM에 반영되지 않아 Lighthouse에서 "name 없음" 경고 발생
* **After**: Button 컴포넌트 내부에 `sr-only` 텍스트 렌더링 로직 추가 → 아이콘만 있는 버튼도 항상 이름을 가지도록 보장  

#### 3) Swiper 네비게이션 버튼 보강
* **Before**: `<GoChevronLeft />`, `<GoChevronRight />` 아이콘만 존재하여 스크린리더 접근 불가
* **After**:
  * `aria-label="이전 룩북 보기"`, `aria-label="다음 룩북 보기"` 추가  
  * `aria-controls="lookbook-carousel"` 속성으로 컨텍스트 연결  

<br/><br/>

**변경 파일**
* `src/pages/LookbookPage.jsx`
  * 이전/다음 버튼에 `aria-label`, `title`, `aria-controls` 추가
* `src/components/Button/Button.jsx`
  * `sr-only` 텍스트 렌더링 로직 추가 (Accessible Name 보장)
  * 아이콘 `aria-hidden="true"` 적용
* `src/components/LookBook/RefreshButton.jsx`
  * 새로고침 버튼에 `aria-label`, `title` 적용

<br/><br/>

**결과**
* **Lighthouse 접근성 점수**: 89점 → 96점 (7점 향상)  
<p align="center">
  <img src="https://github.com/user-attachments/assets/1f191941-0db3-4816-8cc0-cc823d5e1965" width="46%" alt="룩북 접근성 - lighthouse 이전 검사 결과"/>
  <img src="https://github.com/user-attachments/assets/46125e3d-e53b-4d8f-adc7-32987cb15e9e" width="46%" alt="룩북 접근성 - lighthouse 개선 이후 검사 결과"/>
</p>

* **axe DevTools**: 이슈 7건 → 4건 (Critical 이슈 전부 해결, Color Contrast만 남음)  
<p align="center">
  <img src="https://github.com/user-attachments/assets/67709528-44bf-456b-92e1-ffe0d2ada6a0" width="46%" alt="룩북 접근성 - axe DevTools 이전 검사 결과"/>
  <img src="https://github.com/user-attachments/assets/86ff700c-e659-448a-995e-66a028bec326" width="46%" alt="룩북 접근성 - axe DevTools 개선 이후 검사 결과"/>
</p>

* 스크린리더 사용자도 새로고침/이전/다음 버튼의 의미를 정확히 인식 가능  

<br/><br/>

**향후 개선 과제**
- **Color Contrast 부족**
    - 현재 텍스트/아이콘 대비가 WCAG 2.1 AA 기준에 미달 
    → axe DevTools 툴에서 반복적으로 경고 발생
    - 브랜드 컬러/디자인 가이드라인과 직결되므로 단독 수정 불가
    - 차후 색상 대비 개선 방안을 준비하여 리팩토링 예정

<br/><br/>

**배운 점**
* **아이콘 버튼에는 Accessible Name이 필수**: aria-label 또는 sr-only 텍스트로 반드시 이름을 부여해야 함  
* **자동화 툴 병행 검사 필요**: Lighthouse와 axe DevTools를 함께 사용해야 누락된 이슈까지 확인 가능  
* **점진적 개선 효과**: 작은 수정(라벨 추가)만으로도 점수가 개선되고, 사용자 경험이 눈에 띄게 나아짐

<br/><br/>

**적용 기술**
* React 접근성 속성(`aria-label`, `aria-hidden`, `title`)  
* 스크린리더용 `sr-only` 유틸 클래스  
* Lighthouse, axe DevTools 기반 접근성 검증

